### PR TITLE
Add Name change capability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3643,9 +3643,9 @@
       }
     },
     "simple-svelte-autocomplete": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/simple-svelte-autocomplete/-/simple-svelte-autocomplete-1.1.1.tgz",
-      "integrity": "sha512-enk/+CgJYlQrc5OS6UfDx/So+RjAc5huG40f7bRGSI3ou3dGQcMNtB5mnrx6VHVy+MnZbn1aPnkCx9YSotEl/w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-svelte-autocomplete/-/simple-svelte-autocomplete-1.1.2.tgz",
+      "integrity": "sha512-zmOdwS+jzhwzSUT9rW8wVUQj9VziH5EvvBdcZUMDKTetI256d2d/fKaI8bs74sWQ2DNRtOfzPZyU5sLp1UyuUw==",
       "dev": true
     },
     "simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rollup-plugin-svg": "^2.0.0",
     "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript": "^1.0.1",
-    "simple-svelte-autocomplete": "^1.1.1",
+    "simple-svelte-autocomplete": "^1.1.2",
     "svelte": "^3.0.0",
     "tslib": "^1.10.0",
     "typescript": "^3.7.4"

--- a/src/ColorStyles.svelte
+++ b/src/ColorStyles.svelte
@@ -18,20 +18,23 @@
   export let styles = [];
   export let sendToUI;
 
-  let styleFilter = "";
-  let selectedStyles = [];
-  let colors = [];
-  let hslValues = [];
-  let hue = "";
-  let saturation = "";
-  let lightness = "";
-  let alpha = "";
-  let chrome;
-  let color;
+  let styleFilter = "",
+    selectedStyles = [],
+    colors = [],
+    hslValues = [],
+    hue = "",
+    saturation = "",
+    lightness = "",
+    alpha = "",
+    chrome,
+    color,
+    styleName,
+    styleMatch;
 
   $: disabled = !selectedStyles.length;
 
   function update() {
+    let originalStyleNames = getStyleNames(selectedStyles);
     let originalHue = getHue(selectedStyles);
     let originalSaturation = getSaturation(selectedStyles);
     let originalLightness = getLightness(selectedStyles);
@@ -49,6 +52,10 @@
     }
     if (originalAlpha !== alpha) {
       values.alpha = Number(alpha);
+    }
+    values.styleMatch = styleMatch;
+    if (originalStyleNames !== styleName) {
+      values.styleName = styleName;
     }
 
     sendToUI({
@@ -74,6 +81,10 @@
     ];
 
     return rgbValues.map(c => convertToHsl(c));
+  }
+
+  function getStyleNames(selectedStyles) {
+    return [...new Set(selectedStyles.map(n => n.name))].join(", ");
   }
 
   function getHue(styles) {
@@ -107,6 +118,7 @@
 
   function setSelectedStyles(selected) {
     selectedStyles = selected;
+    styleName = getStyleNames(selected);
     hue = getHue(selectedStyles);
     saturation = getSaturation(selectedStyles);
     lightness = getLightness(selectedStyles);
@@ -186,6 +198,21 @@
             bind:value={alpha} />
         </div>
       </div>
+
+      <Label>Name</Label>
+      <div class="flex flex-between space-x-2">
+        <Input
+          placeholder="Style Name"
+          class="ml-xxsmall mr-xxsmall"
+          name="name"
+          bind:value={styleName} />
+        <Input
+          placeholder="Match (optional)"
+          class="ml-xxsmall mr-xxsmall"
+          name="match"
+          bind:value={styleMatch} />
+      </div>
+
       <div class="mt-xsmall flex ml-xxsmall mr-xxsmall">
         <Button {disabled} on:click={update}>Update styles</Button>
       </div>

--- a/src/TextStyles.svelte
+++ b/src/TextStyles.svelte
@@ -20,20 +20,22 @@
   export let styles = [];
   export let availableFamilies = [];
   export let sendToUI;
-  let styleFilter = "";
-  let currentFamily = {};
-  let availableFontNames = [];
-  let availableWeights = [];
-  let hasAllWeightsAvailable = true;
-  let selectedStyles = [];
-  let fontWeight = "";
-  let newFontWeights = [];
-  let familyName;
-  let fontSize;
-  let lineHeight;
-  let letterSpacing;
-  let weightsDialogVisible = false;
-  let loading = true;
+  let styleFilter = "",
+    currentFamily = {},
+    availableFontNames = [],
+    availableWeights = [],
+    hasAllWeightsAvailable = true,
+    selectedStyles = [],
+    fontWeight = "",
+    newFontWeights = [],
+    familyName,
+    styleName,
+    styleMatch,
+    fontSize,
+    lineHeight,
+    letterSpacing,
+    weightsDialogVisible = false,
+    loading = true;
 
   $: disabled = !selectedStyles.length;
   $: {
@@ -71,6 +73,7 @@
   }
 
   function update() {
+    let originalStyleNames = getStyleNames(selectedStyles);
     let originalFamilyNames = getFamilyNames(selectedStyles);
     let originalFontWeights = getFontWeights(selectedStyles);
     let originalFontSizes = getFontSizes(selectedStyles);
@@ -78,6 +81,10 @@
     let originalLetterSpacings = getLetterSpacings(selectedStyles);
     let values = {};
     values.selectedStyles = selectedStyles;
+    values.styleMatch = styleMatch;
+    if (originalStyleNames !== styleName) {
+      values.styleName = styleName;
+    }
     if (originalFamilyNames !== familyName) {
       values.familyName = familyName;
     }
@@ -88,12 +95,12 @@
       values.fontWeight = fontWeight;
     }
     if (originalFontSizes !== fontSize) {
-      let fontSizeMappings = fontSize.split(",").map(l => l.trim())
+      let fontSizeMappings = fontSize.split(",").map(l => l.trim());
       let newFontSizes = fontSizeMappings.map(fs => Number(fs));
       values.fontSize = newFontSizes;
     }
     if (originalLineHeights !== lineHeight) {
-      let lineHeightMappings = lineHeight.split(",").map(l => l.trim())
+      let lineHeightMappings = lineHeight.split(",").map(l => l.trim());
       let newLineHeights = lineHeightMappings.map(lh => {
         lh = lh.toString();
         var numbers = /^\d+(\.\d+)?$/;
@@ -118,11 +125,11 @@
             unit: "AUTO"
           };
         }
-      })
+      });
       values.lineHeight = newLineHeights;
     }
     if (originalLetterSpacings !== letterSpacing) {
-      let letterSpaceMappings = letterSpacing.split(",").map(l => l.trim())
+      let letterSpaceMappings = letterSpacing.split(",").map(l => l.trim());
       let newLetterSpacings = letterSpaceMappings.map(ls => {
         ls = ls.toString();
         var numbers = /^\d+(\.\d+)?$/;
@@ -143,7 +150,7 @@
             value: Number(ls.slice(0, -1))
           };
         }
-      })
+      });
       values.letterSpacing = newLetterSpacings;
     }
 
@@ -152,6 +159,10 @@
       values,
       variant: "TEXT"
     });
+  }
+
+  function getStyleNames(selectedStyles) {
+    return [...new Set(selectedStyles.map(n => n.name))].join(", ");
   }
 
   function getFamilyNames(selectedStyles) {
@@ -176,6 +187,7 @@
 
   function setSelectedStyles(selected) {
     selectedStyles = selected;
+    styleName = getStyleNames(selected);
     familyName = getFamilyNames(selected);
     fontWeight = getFontWeights(selected);
     fontSize = getFontSizes(selected);
@@ -295,6 +307,7 @@
 
   <hr class="mt-xxsmall" />
   <form on:submit={e => e.preventDefault()}>
+
     <fieldset {disabled}>
       <Label>Family</Label>
       <AutoComplete
@@ -343,6 +356,19 @@
         </div>
       </div>
 
+      <Label>Name</Label>
+      <div class="flex flex-between space-x-2">
+        <Input
+          placeholder="Style Name"
+          class="ml-xxsmall mr-xxsmall"
+          name="name"
+          bind:value={styleName} />
+        <Input
+          placeholder="Match (optional)"
+          class="ml-xxsmall mr-xxsmall"
+          name="match"
+          bind:value={styleMatch} />
+      </div>
       <div class="mt-xsmall flex ml-xxsmall mr-xxsmall">
         <Button {disabled} on:click={update}>Update styles</Button>
       </div>

--- a/src/code.ts
+++ b/src/code.ts
@@ -122,6 +122,8 @@ function convertLetterSpacingToFigma(value) {
 
 function updateTextStyles({
   selectedStyles,
+  styleName,
+  styleMatch,
   familyName,
   fontWeight,
   fontSize,
@@ -153,6 +155,7 @@ function updateTextStyles({
         newLetterSpacing = letterSpacing[0];
       }
     }
+
     if (fontSize) {
       if (fontSize.length > 1) {
         if (fontSize.length === selectedStyles.length) {
@@ -182,6 +185,11 @@ function updateTextStyles({
     let hit = localStyles.find((s) => s.id === selectedStyle.id);
 
     await figma.loadFontAsync({ family, style });
+    if (styleMatch !== null && styleName !== undefined) {
+      hit.name = hit.name.replace(styleMatch, styleName);
+    } else if (styleName) {
+      hit.name = styleName;
+    }
     hit.fontName = {
       family,
       style,
@@ -231,6 +239,8 @@ function getHslFromStyle(style) {
 
 function updateColorStyles({
   selectedStyles,
+  styleName,
+  styleMatch,
   hue,
   saturation,
   lightness,
@@ -253,6 +263,11 @@ function updateColorStyles({
     let opacity = alpha ? alpha : selectedStyle.paints[0].opacity;
     let hit = localStyles.find((s) => s.id === selectedStyle.id);
     hit.paints = [{ color: newColor, type: "SOLID", opacity }];
+    if (styleMatch !== null && styleName !== undefined) {
+      hit.name = hit.name.replace(styleMatch, styleName);
+    } else if (styleName) {
+      hit.name = styleName;
+    }
     return hit;
   });
 }
@@ -266,6 +281,8 @@ function trackEvent(data) {
 
 async function updateStyles({
   selectedStyles,
+  styleName,
+  styleMatch,
   hue,
   saturation,
   lightness,
@@ -284,6 +301,8 @@ async function updateStyles({
     if (variant === "COLOR") {
       styleChanges = updateColorStyles({
         selectedStyles,
+        styleName,
+        styleMatch,
         hue,
         saturation,
         lightness,
@@ -301,6 +320,8 @@ async function updateStyles({
     } else {
       styleChanges = updateTextStyles({
         selectedStyles,
+        styleName,
+        styleMatch,
         familyName,
         fontWeight,
         fontSize,
@@ -332,6 +353,8 @@ figma.ui.onmessage = (msg) => {
   if (msg.type === "update") {
     const {
       selectedStyles,
+      styleName,
+      styleMatch,
       familyName,
       fontWeight,
       fontSize,
@@ -346,6 +369,8 @@ figma.ui.onmessage = (msg) => {
     } = msg;
     updateStyles({
       selectedStyles,
+      styleName,
+      styleMatch,
       familyName,
       fontWeight,
       fontSize,


### PR DESCRIPTION
Adds two new inputs to Text & Color styles: Name, Match (optional)

If only Name is given replaces current style name with given name
If Match is given tries to replace that string with what is entered in Name
somewhat matches Figma's native behaviour, except Figma allows more (add variables such as current name etc)


Fixes #12 