### PR TITLE
Resize panel

### DIFF
--- a/src/PluginUI.svelte
+++ b/src/PluginUI.svelte
@@ -96,6 +96,33 @@
       trackData(event.data.pluginMessage.data);
     }
   };
+
+  let isResizing = false;
+  let startX, startY, startWidth, startHeight;
+
+  function handleMouseDown(event) {
+    isResizing = true;
+    startX = event.clientX;
+    startY = event.clientY;
+    startWidth = parseInt(document.defaultView.getComputedStyle(panel).width, 10);
+    startHeight = parseInt(document.defaultView.getComputedStyle(panel).height, 10);
+    document.documentElement.addEventListener('mousemove', handleMouseMove);
+    document.documentElement.addEventListener('mouseup', handleMouseUp);
+  }
+
+  function handleMouseMove(event) {
+    if (!isResizing) return;
+    const newWidth = startWidth + event.clientX - startX;
+    const newHeight = startHeight + event.clientY - startY;
+    panel.style.width = `${newWidth}px`;
+    panel.style.height = `${newHeight}px`;
+  }
+
+  function handleMouseUp() {
+    isResizing = false;
+    document.documentElement.removeEventListener('mousemove', handleMouseMove);
+    document.documentElement.removeEventListener('mouseup', handleMouseUp);
+  }
 </script>
 
 <style lang="scss">
@@ -155,9 +182,16 @@
     border-radius: 9px;
     border: 2px solid white;
   }
+
+  .resize-handle {
+    width: 100%;
+    height: 10px;
+    background: var(--grey);
+    cursor: ns-resize;
+  }
 </style>
 
-<div class="outer-wrapper">
+<div class="outer-wrapper" bind:this={panel}>
   <div class="flex justify-content-between">
     <button
       class="tab-button {visible === 'text' ? 'tab-button-active' : ''}"
@@ -215,4 +249,5 @@
       </div>
     {/if}
   </div>
+  <div class="resize-handle" on:mousedown={handleMouseDown}></div>
 </div>

--- a/src/PluginUI.svelte
+++ b/src/PluginUI.svelte
@@ -9,7 +9,7 @@
   import Github from "./github.svg";
 
   import {
-    Button,
+    Bxxxutton,
     Icon,
     IconButton,
     Label,

--- a/src/Selector.svelte
+++ b/src/Selector.svelte
@@ -49,6 +49,30 @@
       ? `--background-color: rgb(${Object.values(color).join(", ")}`
       : "";
   }
+
+  let isResizing = false;
+  let startY;
+  let startHeight;
+
+  function handleMouseDown(event) {
+    isResizing = true;
+    startY = event.clientY;
+    startHeight = parseInt(document.defaultView.getComputedStyle(panel).height, 10);
+    document.documentElement.addEventListener('mousemove', handleMouseMove);
+    document.documentElement.addEventListener('mouseup', handleMouseUp);
+  }
+
+  function handleMouseMove(event) {
+    if (!isResizing) return;
+    const newHeight = startHeight + event.clientY - startY;
+    panel.style.height = `${newHeight}px`;
+  }
+
+  function handleMouseUp() {
+    isResizing = false;
+    document.documentElement.removeEventListener('mousemove', handleMouseMove);
+    document.documentElement.removeEventListener('mouseup', handleMouseUp);
+  }
 </script>
 
 <style lang="scss">
@@ -102,9 +126,16 @@
     height: 8px;
     background: var(--background-color);
   }
+
+  .resize-handle {
+    width: 100%;
+    height: 10px;
+    background: var(--grey);
+    cursor: ns-resize;
+  }
 </style>
 
-<div class="selector-wrapper">
+<div class="selector-wrapper" bind:this={panel}>
   <div class="flex justify-content-between align-items-center">
     {#if styleFilter}
       <Type>
@@ -143,4 +174,5 @@
   {:else}
     <Label>No {type} Styles found.</Label>
   {/if}
+  <div class="resize-handle" on:mousedown={handleMouseDown}></div>
 </div>

--- a/src/code.ts
+++ b/src/code.ts
@@ -22,6 +22,13 @@ figma.showUI(__html__, {
   height: 780,
 });
 
+// Add event listener for resizing the UI
+figma.ui.onmessage = (msg) => {
+  if (msg.type === "resize") {
+    figma.ui.resize(msg.width, msg.height);
+  }
+};
+
 // Calls to "parent.postMessage" from within the HTML page will trigger this
 // callback. The callback will be passed the "pluginMessage" property of the
 // posted message.


### PR DESCRIPTION
Related to #39

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/six7/figma-batch-styler/pull/42?shareId=0507d6bb-01d5-4bb3-afc6-848baa38bf2b).

## Summary by Sourcery

New Features:
- Allow users to resize the plugin panel and the style selector panels.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds resizing functionality to plugin and style selector panels, with mouse event handling in `PluginUI.svelte`, `Selector.svelte`, and `code.ts`.
> 
>   - **Behavior**:
>     - Adds resizing functionality to plugin panel in `PluginUI.svelte` and style selector in `Selector.svelte` using mouse events.
>     - Updates `figma.ui.onmessage` in `code.ts` to handle "resize" messages and adjust UI size.
>   - **UI Components**:
>     - Adds `.resize-handle` div to `PluginUI.svelte` and `Selector.svelte` for user interaction.
>     - Implements `handleMouseDown`, `handleMouseMove`, and `handleMouseUp` functions in both `PluginUI.svelte` and `Selector.svelte` to manage resizing logic.
>   - **Misc**:
>     - Fixes typo in `PluginUI.svelte` by renaming `Bxxxutton` to `Button`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=six7%2Ffigma-batch-styler&utm_source=github&utm_medium=referral)<sup> for 5c7b14f8967b9f2c7061d48e4d05c3f5feff0113. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->