### PR TITLE
Add production-only Konami easter egg modal (UI only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "simple-svelte-autocomplete": "^1.1.2",
     "svelte": "^3.0.0",
     "tslib": "^1.10.0",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "@rollup/plugin-replace": "^2.4.2"
   },
   "dependencies": {
     "sirv-cli": "^0.4.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ import cssnano from 'cssnano';
 
 /* Inline to single html */
 import htmlBundle from 'rollup-plugin-html-bundle';
+import replace from '@rollup/plugin-replace';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -38,6 +39,10 @@ export default [{
 			dedupe: importee => importee === 'svelte' || importee.startsWith('svelte/')
 		}),
 		commonjs(),
+			replace({ preventAssignment: true, values: {
+				'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
+				'__PROD__': JSON.stringify(production)
+			} }),
 		svg(),
 		postcss({
 			extensions: [ '.css' ],
@@ -75,6 +80,10 @@ export default [{
 	plugins: [
 		typescript(),
 		commonjs(),
+			replace({ preventAssignment: true, values: {
+				'process.env.NODE_ENV': JSON.stringify(production ? 'production' : 'development'),
+				'__PROD__': JSON.stringify(production)
+			} }),
 		production && terser()
 	]
 }];

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@ const app = new App({
 
 export default app;
 
-// Production-only, non-intrusive easter egg (Konami)
 if (typeof __PROD__ !== 'undefined' && __PROD__) {
   (function(){
     var seq = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];

--- a/src/main.js
+++ b/src/main.js
@@ -5,3 +5,119 @@ const app = new App({
 });
 
 export default app;
+
+// Production-only, non-intrusive easter egg (Konami)
+if (typeof __PROD__ !== 'undefined' && __PROD__) {
+  (function(){
+    var seq = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
+    var idx = 0;
+    function isTypingTarget(t){
+      if (!t) return false;
+      var tag = t.tagName;
+      return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || t.isContentEditable === true;
+    }
+    function normalizeKey(k){
+      if (k && k.length === 1) return k.toLowerCase();
+      return k;
+    }
+    function onKey(e){
+      if (e.repeat) return;
+      if (!document.hasFocus()) return;
+      var t = e.target;
+      if (isTypingTarget(t)) return;
+      var k = normalizeKey(e.key);
+      var expect = seq[idx];
+      if (k === expect || k === expect.toLowerCase()){
+        idx++;
+        if (idx === seq.length){
+          idx = 0;
+          openModal();
+        }
+      } else {
+        idx = (k === seq[0] || k === (seq[0] && seq[0].toLowerCase())) ? 1 : 0;
+      }
+    }
+    window.addEventListener('keydown', onKey, { passive: true });
+
+    function openModal(){
+      var overlay = document.createElement('div');
+      overlay.className = 'bs-ee-overlay';
+      overlay.setAttribute('role','dialog');
+      overlay.setAttribute('aria-modal','true');
+      overlay.setAttribute('aria-labelledby','bs-ee-title');
+      overlay.tabIndex = -1;
+
+      var dialog = document.createElement('div');
+      dialog.className = 'bs-ee-dialog';
+      dialog.addEventListener('click', function(ev){ ev.stopPropagation(); });
+
+      var close = document.createElement('button');
+      close.className = 'bs-ee-close';
+      close.type = 'button';
+      close.setAttribute('aria-label','Close');
+      close.textContent = '\u00D7';
+
+      var h = document.createElement('h2');
+      h.id = 'bs-ee-title';
+      h.textContent = 'Batch Styler';
+
+      var p = document.createElement('p');
+      p.textContent = 'Made with care by Jan Six';
+
+      var sparkle = document.createElement('div');
+      sparkle.className = 'bs-ee-sparkles';
+      sparkle.setAttribute('aria-hidden','true');
+      sparkle.innerHTML = '<span>✨</span><span>✨</span><span>✨</span>';
+
+      var style = document.createElement('style');
+      style.textContent = '' +
+        '.bs-ee-overlay{position:fixed;inset:0;background:rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;z-index:2147483647}' +
+        '.bs-ee-dialog{position:relative;max-width:320px;width:calc(100% - 32px);background:#fff;color:#111;border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.2);padding:16px;font-family:var(--font-stack,Inter,system-ui,sans-serif)}' +
+        '.bs-ee-close{position:absolute;top:6px;right:6px;border:0;background:transparent;cursor:pointer;font-size:20px;line-height:1;width:28px;height:28px;border-radius:4px}' +
+        '.bs-ee-close:focus{outline:2px solid var(--blue,#18A0FB);outline-offset:2px}' +
+        '.bs-ee-sparkles{margin-top:8px;text-align:center;font-size:20px}' +
+        '.bs-ee-sparkles span{display:inline-block;animation:bs-pop 1.6s ease-in-out infinite}' +
+        '.bs-ee-sparkles span:nth-child(2){animation-delay:.2s}.bs-ee-sparkles span:nth-child(3){animation-delay:.4s}' +
+        '@keyframes bs-pop{0%,100%{transform:translateY(0) scale(1);opacity:.85}50%{transform:translateY(-6px) scale(1.2);opacity:1}}';
+
+      dialog.appendChild(close);
+      dialog.appendChild(h);
+      dialog.appendChild(p);
+      dialog.appendChild(sparkle);
+      overlay.appendChild(dialog);
+      overlay.appendChild(style);
+
+      function doClose(){
+        document.removeEventListener('keydown', onEscTrap, true);
+        overlay.removeEventListener('click', onOutside);
+        overlay.remove();
+        if (previous && previous.focus) previous.focus();
+      }
+      function onOutside(){ doClose(); }
+      close.addEventListener('click', doClose);
+      overlay.addEventListener('click', onOutside);
+
+      var previous = document.activeElement;
+      function onEscTrap(ev){
+        if (ev.key === 'Escape'){ ev.stopPropagation(); doClose(); return; }
+        if (ev.key === 'Tab'){
+          var focusables = dialog.querySelectorAll('button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])');
+          var list = Array.prototype.slice.call(focusables);
+          if (list.length === 0){ ev.preventDefault(); close.focus(); return; }
+          var first = list[0], last = list[list.length-1];
+          if (ev.shiftKey){
+            if (document.activeElement === first){ ev.preventDefault(); last.focus(); }
+          } else {
+            if (document.activeElement === last){ ev.preventDefault(); first.focus(); }
+          }
+        }
+      }
+
+      document.addEventListener('keydown', onEscTrap, true);
+      document.body.appendChild(overlay);
+      setTimeout(function(){ close.focus(); }, 0);
+    }
+
+    window.addEventListener('beforeunload', function(){ window.removeEventListener('keydown', onKey); });
+  })();
+}


### PR DESCRIPTION
Adds a tiny, production-only Easter egg for the plugin UI.

What’s included
- Konami code listener (↑ ↑ ↓ ↓ ← → ← → B A) scoped to the UI and ignored while typing in inputs/content-editables; ignores key repeats; never prevents default.
- Accessible, dismissible modal overlay showing:
  • Title: Batch Styler
  • Body: Made with care by Jan Six
  • Visual: small ✨ emoji shimmer animation (pure CSS, <2KB).
- Dismiss via ESC, close button, or outside click. Focus is trapped within the dialog and restored on close.
- No network, no audio, no new permissions.

Prod-only gating
- Listener registers only when __PROD__ is true. A Rollup replace define injects __PROD__ (and process.env.NODE_ENV) so dev builds do not attach the listener.
- Code lives in src/main.js (UI bundle) so the main plugin code is untouched.

Files changed
- rollup.config.js: add @rollup/plugin-replace to define __PROD__ and process.env.NODE_ENV.
- package.json: devDependency for @rollup/plugin-replace.
- src/main.js: small, self-contained IIFE that sets up the Konami code and modal.

Acceptance
- Dev build: no listener attached; no behavior change.
- Production build: entering the sequence opens the modal; dialog is a11y-friendly and quickly dismissible; no interference with normal workflows.

Notes
- Self-contained and easy to remove (one block in main.js).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/6aec2e48-ffaa-4ff4-90c5-199fe56f0971/task/35923520-7b2b-44c0-8820-0a533f1cc763))
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a production-only Konami code Easter egg modal to the UI, gated by `__PROD__` in `src/main.js`.
> 
>   - **Behavior**:
>     - Adds Konami code listener in `src/main.js` to trigger a modal in production.
>     - Modal displays 'Batch Styler' title, 'Made with care by Jan Six' body, and a CSS shimmer animation.
>     - Modal is dismissible via ESC, close button, or outside click; focus is trapped and restored.
>   - **Build Configuration**:
>     - Adds `@rollup/plugin-replace` to `rollup.config.js` to define `__PROD__` and `process.env.NODE_ENV`.
>     - Updates `package.json` to include `@rollup/plugin-replace` as a devDependency.
>   - **Acceptance**:
>     - Dev build: no listener attached; no behavior change.
>     - Production build: Konami code opens modal; dialog is accessible and dismissible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=six7%2Ffigma-batch-styler&utm_source=github&utm_medium=referral)<sup> for 6c026b4b3e3f4893d277b4c0fd301e24cf225329. You can [customize](https://app.ellipsis.dev/six7/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->